### PR TITLE
Subcell differentiation

### DIFF
--- a/multiomicscellsim/config.py
+++ b/multiomicscellsim/config.py
@@ -48,6 +48,9 @@ class SimulatorConfig(BaseModel):
     tissue_folder: str = Field(default="tissues", description="Name of the subfolder containing tissues")
     n_simulations: int = Field(description="How many tissues to generate")
 
+    on_error: Literal["continue", "raise"] = Field("continue", description="What to do when an error occurs during tissue generation. 'continue' will log the error and continue to the next tissue. 'raise' will raise an exception and stop the simulation.")
+
+
     @staticmethod
     def from_yaml(path: Path) -> "SimulatorConfig":
         """

--- a/multiomicscellsim/simulator.py
+++ b/multiomicscellsim/simulator.py
@@ -151,6 +151,8 @@ class Simulator:
             except Exception as e:
                 logger.error(f"Generation of tissue {tissue_id} with seed {tissue_seed} failed. Dumping seed to file. Error: {e}")
                 self.log_error_seed(dataset_folder.joinpath("failed_seeds.log"), seed=tissue_seed)
+                if self.config.on_error == "raise":
+                    raise e
         return tissues
     
     def plot_tissue(self, t: Tissue, axs=None):

--- a/multiomicscellsim/tissue_generator.py
+++ b/multiomicscellsim/tissue_generator.py
@@ -193,7 +193,8 @@ class TissueGenerator():
                                          radius=self.tissue_config.initial_cell_radius,
                                          edges=self.tissue_config.initial_cell_edges,
                                          orientation=self.tissue_config.initial_cell_orientation,
-                                         cell_type=cell_type.id
+                                         cell_type=cell_type.id,
+                                         subcell_init_noise=cell_type.subcell_initial_noise,
                                         )
                 # cell_id is 0 if write failed
                 if cell_id > 0:

--- a/multiomicscellsim/tissue_generator.py
+++ b/multiomicscellsim/tissue_generator.py
@@ -188,23 +188,36 @@ class TissueGenerator():
             for centroid, cpm_cell_coord in zip(centroids, cpm_cell_centroids):
                 cell_type = random.choices(population=self.cpm_config.cell_types,
                                            weights=self.tissue_config.cell_type_probabilities[g])[0]
-                cell_id = cpm.draw_cell( xc=cpm_cell_coord[0], 
+                cpm_cell = cpm.draw_cell( 
+                                         xc=cpm_cell_coord[0], 
                                          yc=cpm_cell_coord[1], 
                                          radius=self.tissue_config.initial_cell_radius,
                                          edges=self.tissue_config.initial_cell_edges,
                                          orientation=self.tissue_config.initial_cell_orientation,
-                                         cell_type=cell_type.id,
+                                         cell_type_id=cell_type.id,
                                          subcell_init_noise=cell_type.subcell_initial_noise,
                                         )
-                # cell_id is 0 if write failed
-                if cell_id > 0:
-                    cells.append(Cell(cell_id=cell_id,
+                
+                # cpm_cell is None if the cell could not be spawned
+                if cpm_cell is not None:
+                    cells.append(Cell(cell_id=cpm_cell.id,
                                       cell_type=cell_type,
                                       start_coordinates_cpm = cpm_cell_coord,
                                       start_coordinates=centroid,
+                                      params=CellParams(
+                                        f=cpm_cell.f,
+                                        k=cpm_cell.k,
+                                        d_a=cpm_cell.d_a,
+                                        d_b=cpm_cell.d_b,
+                                        # These will be extracted from the subcellular grid on save
+                                        a_avg=0,
+                                        a_std=0,
+                                        b_avg=0,
+                                        b_std=0                                        
+                                      ),
                                       )
                                  )
-                    gl.spawned_cell_ids.append(cell_id)
+                    gl.spawned_cell_ids.append(cpm_cell.id)
 
         tissues = list()
 
@@ -236,23 +249,20 @@ class TissueGenerator():
         """
 
         for cell in cells:
-
             cell_mask = (cell_grid[0]==cell.cell_id)
             A_subcellular = subcell_grid[0][cell_mask].numpy()
             B_subcellular = subcell_grid[1][cell_mask].numpy()
-
-            # TODO: For now we are taking the params directly from the cell type itself.
-            # If we implement some cell variability we should take it from wherever we store (maybe a pre-existing params value?)
-            cell.params = CellParams(
-                f=cell.cell_type.subcellular_pattern.f,
-                k=cell.cell_type.subcellular_pattern.k,
-                d_a=cell.cell_type.subcellular_pattern.d_a,
-                d_b=cell.cell_type.subcellular_pattern.d_b,
+            new_params = CellParams(
+                f=cell.params.f,
+                k=cell.params.k,
+                d_a=cell.params.d_a,
+                d_b=cell.params.d_b,
                 a_avg=A_subcellular.mean(),
                 a_std=A_subcellular.std(),
                 b_avg=B_subcellular.mean(),
                 b_std=B_subcellular.std()
             )
+            cell.params = new_params
         return deepcopy(cells)
 
     def plot_debug(self, tissue: Tissue, size: int = 8):

--- a/multiomicscellsim/torch_cpm/config.py
+++ b/multiomicscellsim/torch_cpm/config.py
@@ -1,5 +1,5 @@
 from pydantic import BaseModel, Field
-from typing import List, Dict, Optional, Union
+from typing import List, Dict, Optional, Union, Literal
 import torch
 from functools import cached_property
 from multiomicscellsim.patterns.config import RDPatternConfig, ReactionDiffusionConfig
@@ -15,6 +15,9 @@ class TorchCPMCellType(BaseModel):
     preferred_volume: int = Field(None, description="Preferred volume for this cell type. Used with VolumeConstraint.")
     preferred_local_perimeter: int = Field(8, description="Preferred local perimeter for this cell type. Used with LocalPerimeterConstraint. 3: edges try to be flat and either vertical or horizontal. Greater numbers increases rougness or cuvature")
     subcellular_pattern: Union[None, RDPatternConfig] = Field(None, description="Subcellular pattern to use for this cell type. If None, no subcellular simulation will be run for this cell type.")
+    
+
+    subcell_initial_noise: Union[None, Literal["bernoulli"]] = Field(None, description="Initial noise pattern in the simulation. Allows to introduce some randomness in the initial state of the simulation and promote pattern development.")
     
 
     @staticmethod

--- a/multiomicscellsim/torch_cpm/config.py
+++ b/multiomicscellsim/torch_cpm/config.py
@@ -5,6 +5,11 @@ from functools import cached_property
 from multiomicscellsim.patterns.config import RDPatternConfig, ReactionDiffusionConfig
 
 class TorchCPMCellType(BaseModel):
+    """
+        Represents a cell type in the CPM model.
+        Hosts the parameters for the cell type, such as adhesion, preferred volume, etc.
+        For the subcellular simulation, it also hosts the input parameters for the RD model.
+    """
     id: int = Field(1, description="Unique Identifier for the cell type. Cannot be 0 for consistency with pixel values")
     name: Optional[str] = Field("", description="Human Readable name of the cell type")
     
@@ -16,8 +21,13 @@ class TorchCPMCellType(BaseModel):
     preferred_local_perimeter: int = Field(8, description="Preferred local perimeter for this cell type. Used with LocalPerimeterConstraint. 3: edges try to be flat and either vertical or horizontal. Greater numbers increases rougness or cuvature")
     subcellular_pattern: Union[None, RDPatternConfig] = Field(None, description="Subcellular pattern to use for this cell type. If None, no subcellular simulation will be run for this cell type.")
     
+    subcell_f_std: float = Field(0.0005, description="Standard deviation for differentiating feed ratio in the subcellular simulation")
+    subcell_k_std: float = Field(0.0005, description="Standard deviation for differentiating kill ratio in the subcellular simulation")
+    subcell_da_std: float = Field(0, description="Standard deviation for differentiating diffusion of A layer in the subcellular simulation")
+    subcell_db_std: float = Field(0, description="Standard deviation for differentiating diffusion of B layer in the subcellular simulation")
+    
 
-    subcell_initial_noise: Union[None, Literal["bernoulli"]] = Field(None, description="Initial noise pattern in the simulation. Allows to introduce some randomness in the initial state of the simulation and promote pattern development.")
+    subcell_initial_noise: Union[None, Literal["bernoulli"]] = Field("bernoulli", description="Initial noise pattern in the simulation. Allows to introduce some randomness in the initial state of the simulation and promote pattern development.")
     
 
     @staticmethod
@@ -36,6 +46,19 @@ class TorchCPMCellType(BaseModel):
     
     class Config:
         arbitrary_types_allowed = True
+
+class TorchCPMCell(BaseModel):
+    """
+        Represents a cell instance as seen by the CPM model.
+    """
+
+    id: int = Field(0, description="Unique Identifier for the cell. Cannot be 0 for consistency with pixel values in CPM grid.")
+    cell_type: TorchCPMCellType = Field(None, description="Cell type for this cell.")
+    f: float = Field(0.0, description="Actual (sampled) feed rate value for this cell. Used in the subcellular simulation.")
+    k: float = Field(0.0, description="Actual (sampled) kill rate value for this cell. Used in the subcellular simulation.")
+    d_a: float = Field(0.0, description="Actual (sampled) diffusion rate for the A layer in the subcellular simulation.")
+    d_b: float = Field(0.0, description="Actual (sampled) diffusion rate for the B layer in the subcellular simulation.")
+
 
 class TorchCPMConfig(BaseModel):
     size: int = Field(256, description="Size of the grid for the CPM simulation.")


### PR DESCRIPTION
- Now the Reaction Diffusion parameters are slighly different for each cell belonging to the same cell type. This variability is controlled by a new set of parameters in the CellType.
- Sampling occurs during the `draw_cell` function, which now returns a new `TorchCPMCell` containing the sampled parameters. 
- A list of such object is also hold in the CPM simulator to be accessed during the RD updates.
- `run_reaction_diffusion_on_cells()` has been simplified since now there's no need anymore to select cells based on their type. A simple iteration over the cells is enough.
